### PR TITLE
Update linux-ci for macos and all ci for action updates for Node.js

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -24,28 +24,28 @@ jobs:
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
-          - os: macos-15-intel
+          - os: macos-26-intel
             build_static: false
-            flags: CC=clang CXX=clang++ OSX=15
+            flags: CC=clang CXX=clang++
             download_requirements: brew install metis bash
-          - os: macos-15-intel
+          - os: macos-26
             build_static: false
-            flags: CC=gcc-15 CXX=g++-15 OSX=15 ADD_CXXFLAGS=-Wl,-ld_classic
+            flags: CC=gcc-15 CXX=g++-15 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
-          - os: macos-14
-            arch: arm64
+          - os: macos-15
             build_static: false
-            flags: CC=gcc-13 CXX=g++-13 OSX=14 ADD_CXXFLAGS=-Wl,-ld_classic
+            flags: CC=clang CXX=clang++
             download_requirements: brew install metis bash
+
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}
       - name: Install required packages from package manager
         run: ${{ matrix.download_requirements }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -72,7 +72,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
           tar -czvf release.tar.gz -C dist .
       - name: Checkout package name generation script
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or-tools/platform-analysis-tools
           path: tools
@@ -86,7 +86,7 @@ jobs:
           platform_str=`python3 tools/hsf_get_platform.py -b $buildtype`
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -38,7 +38,7 @@ jobs:
           path: coinbrew
       - name: Set up msvc
         if: ${{ matrix.arch == 'msvc' }}
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: egor-tensin/vs-shell@v2
       - name: Set correct host flag and install requirements
         if: ${{ matrix.arch != 'msvc' }}
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -28,11 +28,11 @@ jobs:
         ]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.event.repository.name }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -70,7 +70,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
         shell: msys2 {0}
       - name: Upload failed build directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: ${{ matrix.os}}-{{ matrix.arch }}-debug=${{ matrix.debug }}-failedbuild
@@ -87,7 +87,7 @@ jobs:
         shell: msys2 {0}
         if: ${{ matrix.arch != 'msvc' }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ github.event.repository.name }}-${{ env.package_suffix }}
           path: dist

--- a/src/BlisModel.cpp
+++ b/src/BlisModel.cpp
@@ -1720,7 +1720,7 @@ TERM_FEAS_HEUR:
     
     if (rowAct) delete [] rowAct;
 
-    addFeasCheckTime(CoinWallclockTime(start)-start);
+    addFeasCheckTime(CoinWallclockTime()-start);
     return blisSol;
 }
 


### PR DESCRIPTION
- Update linux-ci to add the new macos-26 and macos-26-intel runners.
-- Simplify the combinations of macos and compilers (gcc / clang)
-- Reduce the number of MaxOS builds to only the two most recent MacOS, and intel only for the latest MacOS
-- Remove "OSX=xx" flags. It seems not used?
-- Remove "arch: arm64" for macos-14. It seems not used?
See also https://docs.github.com/en/actions/reference/runners/github-hosted-runners

- Update update all ci.yml for several actions to recent versions that use Node 24 rather than the old Node 20. See recent Action warnings.

See also [COIN-OR-OptimizationSuite issue 36](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/36) discussion.